### PR TITLE
fix(utils): 修复鼠标事件坐标计算问题

### DIFF
--- a/packages/plugin/src/utils/utils.ts
+++ b/packages/plugin/src/utils/utils.ts
@@ -2,12 +2,21 @@ import { Camera, Vector2, Vector3 } from "three";
 import { TileMap } from "three-tile";
 
 export function getLocalFromMouse(
-	mouseEvent: { currentTarget: any; clientX: number; clientY: number },
+	mouseEvent:MouseEvent,
 	map: TileMap,
 	camera: Camera
 ): Vector3 | undefined {
-	const { currentTarget: target, clientX: x, clientY: y } = mouseEvent;
-	if (target instanceof HTMLElement) {
+	const { currentTarget: target } = mouseEvent;
+	let x=0,y=0;
+	if( mouseEvent.offsetX){
+		x = mouseEvent.offsetX;
+		y = mouseEvent.offsetY;
+	}else{
+		const {left,top} = (mouseEvent.currentTarget as HTMLDivElement).getBoundingClientRect()
+		x = mouseEvent.clientX - left;
+		y = mouseEvent.clientY - top;
+	}
+if (target instanceof HTMLElement) {
 		const width = target.clientWidth;
 		const height = target.clientHeight;
 		const pointer = new Vector2((x / width) * 2 - 1, -(y / height) * 2 + 1);


### PR DESCRIPTION
原代码在处理鼠标事件坐标时存在潜在问题，如果canvas元素不是对齐屏幕左上角就会出现偏差。现改进为：
1. 优先使用offsetX/Y获取相对坐标。
2. 当offsetX/Y不存在时，通过getBoundingClientRect计算相对位置
3. 明确参数类型为MouseEvent